### PR TITLE
Quotes for the `pip install` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ terminal.
 Get `rich-pixels` from PyPI.
 
 ```
-pip install rich-pixels[image]
+pip install "rich-pixels[image]"
 ```
 
 Be sure to install the `image` extras if you want to display images!


### PR DESCRIPTION
The example `pip install` command doesn't work without quotes on zsh, as square brackets are not interpreted literally.