### PR TITLE
fix: PIL ^9.1.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -10,7 +10,7 @@ python-versions = ">=3.5"
 dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy (>=0.900,!=0.940)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "sphinx", "sphinx-notfound-page", "zope.interface"]
 docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
 tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "zope.interface"]
-tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
+tests_no_zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
 
 [[package]]
 name = "black"
@@ -314,7 +314,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "7ae23c23df270174b20efde8129b444978a808942045bf0089655cdb9465bc55"
+content-hash = "ffbf706c32e5ba9539e66f6a74b1461e5c587540e140dbb950c4e1211fa95678"
 
 [metadata.files]
 attrs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ include = ["rich_pixels/py.typed"]
 [tool.poetry.dependencies]
 python = "^3.7"
 rich = ">=12.0.0"
-pillow = "^9.0.0"
+pillow = "^9.1.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "^22.10.0"


### PR DESCRIPTION
This PR updates the dependency on Pillow to `^9.1.0` from `^9.0.0`. The `PIL.Image.Resampling` API didn't arrive until `9.1.0`:

- https://github.com/darrenburns/rich-pixels/blob/bc0f00ee215ef744c55a830b115c549016cf7148/rich_pixels/_pixel.py#L8
- https://github.com/python-pillow/Pillow/blob/9.0.0/src/PIL/Image.py
- https://github.com/python-pillow/Pillow/commit/f8e4e9c2dd94c6f4789639dd891b8a6d5fb16e14
